### PR TITLE
Defined types visit support

### DIFF
--- a/packages/renderers-dart/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-dart/src/getTypeManifestVisitor.ts
@@ -1,23 +1,26 @@
 import {
+    ArrayTypeNode,
+    isNode,
+    parseDocs,
+    pascalCase,
     REGISTERED_TYPE_NODE_KINDS,
     REGISTERED_VALUE_NODE_KINDS,
-    isNode,
-    pascalCase,
     snakeCase,
     structTypeNodeFromInstructionArgumentNodes,
-    parseDocs
 } from '@codama/nodes';
 import { extendVisitor, mergeVisitor, pipe, visit } from '@codama/visitors-core';
 
-import { dartDocblock } from './utils';
+import { getDartTypedArrayType } from './fragments/dartTypedArray';
 import { ImportMap } from './ImportMap';
+import { dartDocblock } from './utils';
 
-
-export type TypeManifest = {
+type TypeManifest = {
     imports: ImportMap;
-    type: string;
     nestedStructs: string[];
+    type: string;
 };
+
+export default TypeManifest;
 
 export type GetImportFromFunction = (node: any) => string;
 
@@ -25,6 +28,10 @@ export type TypeManifestOptions = {
     getImportFrom: GetImportFromFunction;
     nestedStruct?: boolean;
     parentName?: string | null;
+};
+
+export const structManifestMap: Record<string, TypeManifest> = {
+
 };
 
 export function getTypeManifestVisitor(options: TypeManifestOptions) {
@@ -35,11 +42,11 @@ export function getTypeManifestVisitor(options: TypeManifestOptions) {
 
     return pipe(
         mergeVisitor(
-            (): TypeManifest => ({ imports: new ImportMap(), type: '', nestedStructs: [] }),
+            (): TypeManifest => ({ imports: new ImportMap(), nestedStructs: [], type: '' }),
             (_: any, values: any[]) => ({
                 imports: new ImportMap().mergeWith(...values.map((v: any) => v.imports)),
-                type: values.map((v: any) => v.type).join('\n'),
                 nestedStructs: values.flatMap((v: any) => v.nestedStructs),
+                type: values.map((v: any) => v.type).join('\n'),
             }),
             {
                 keys: [
@@ -54,46 +61,58 @@ export function getTypeManifestVisitor(options: TypeManifestOptions) {
         ),
         (v: any) =>
             extendVisitor(v, {
-                visitAccount(account: any, { self }: { self: any }) {
+                visitAccount(account: any, { self }: { self: any }): TypeManifest {
                     parentName = pascalCase(account.name);
                     const manifest = visit(account.data, self) as TypeManifest;
                     parentName = null;
                     return manifest;
                 },
 
-                visitArrayType(arrayType: any, { self }: { self: any }) {
-                    const childManifest = visit(arrayType.item, self) as TypeManifest;
-
-                    if (isNode(arrayType.count, 'fixedCountNode')) {
-                        return {
-                            ...childManifest,
-                            type: `List<${childManifest.type}> /* length: ${arrayType.count.value} */`,
-                        };
+                visitArrayType(arrayType: ArrayTypeNode , { self }: { self: any}): TypeManifest {
+                    /*
+                    ArrayTypeNode structure:
+                    https://github.com/codama-idl/codama/blob/main/packages/nodes/docs/typeNodes/ArrayTypeNode.md
+                    */
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+                    const childManifest = visit(arrayType.item, self) as TypeManifest; // Item
+                    
+                    // console.log('===========Array Type ', arrayType);
+                    const typedArrayManifest = getDartTypedArrayType(arrayType.item, childManifest);
+                    if (typedArrayManifest) {
+                        if (isNode(arrayType.count, 'fixedCountNode')) {
+                            // Fixed-size typed array handler
+                            return {
+                                ...typedArrayManifest,
+                                // type: `${typedArrayManifest.type} /* length: ${arrayType.count.value} */`,
+                                type: `${typedArrayManifest.type}`,
+                            };
+                        }
+                        return typedArrayManifest;
                     }
 
                     return {
                         ...childManifest,
                         type: `List<${childManifest.type}>`,
-                    };
+                    }
                 },
 
-                visitBooleanType(_booleanType: any) {
+                visitBooleanType(_booleanType: any): TypeManifest {
                     return {
                         imports: new ImportMap(),
-                        type: 'bool',
                         nestedStructs: [],
+                        type: 'bool',
                     };
                 },
 
-                visitBytesType() {
+                visitBytesType(): TypeManifest {
                     return {
                         imports: new ImportMap().add('dart:typed_data', ['Uint8List']),
-                        type: 'Uint8List',
                         nestedStructs: [],
+                        type: 'Uint8List',
                     };
                 },
 
-                visitDefinedType(definedType: any, { self }: { self: any }) {
+                visitDefinedType(definedType: any, { self }: { self: any }): TypeManifest {
                     parentName = pascalCase(definedType.name);
                     const manifest = visit(definedType.type, self) as TypeManifest;
                     parentName = null;
@@ -101,16 +120,18 @@ export function getTypeManifestVisitor(options: TypeManifestOptions) {
                     const renderedType = isNode(definedType.type, ['enumTypeNode', 'structTypeNode'])
                         ? manifest.type
                         : `typedef ${pascalCase(definedType.name)} = ${manifest.type};`;
-
-                    return { ...manifest, type: renderedType };
+                    
+                    return { ...manifest, type: renderedType};
                 },
 
-                visitDefinedTypeLink(node: any) {
-                    const pascal = pascalCase(node.name);
+                visitDefinedTypeLink(node: any): TypeManifest {
+                    const snake_case = snakeCase(node.name); // This is the correct way to name files in Dart
+                    const pascal_case = pascalCase(node.name); // This is the correct way to name types in Dart
+                    // Example: types/simple_struct.dart -> SimpleStruct (is the actual type name)
                     const importFrom = getImportFrom(node);
                     return {
-                        imports: new ImportMap().add(`${importFrom}::${pascal}`, [pascal]),
-                        type: pascal,
+                        imports: new ImportMap().add(`../${importFrom}/${snake_case}.dart`, [snake_case]),
+                        type: pascal_case,
                         nestedStructs: [],
                     };
                 },
@@ -120,26 +141,26 @@ export function getTypeManifestVisitor(options: TypeManifestOptions) {
                     return {
                         imports: new ImportMap(),
                         nestedStructs: [],
-                        type: `${name},`,
+                        type: `class ${name} extends ${parentName} {}`
                     };
                 },
 
                 visitEnumStructVariantType(enumStructVariantType: any, { self }: { self: any }) {
                     const name = pascalCase(enumStructVariantType.name);
                     const originalParentName = parentName;
-
-                    // Use a default name if no parent name is available
-                    const variantParentName = originalParentName || 'AnonymousEnum';
-
+                    
                     inlineStruct = true;
-                    parentName = pascalCase(variantParentName) + name;
+                    // Sets the name of the parent to the variant name only
+                    parentName = name;
                     const typeManifest = visit(enumStructVariantType.struct, self) as TypeManifest;
                     inlineStruct = false;
+                    // Set the Parent name back to the original parent name(Enum class name)
                     parentName = originalParentName;
-
+                    
                     return {
                         ...typeManifest,
-                        type: `${name} ${typeManifest.type},`,
+                        type: `class ${name} extends ${parentName}
+                            ${typeManifest.type}`,
                     };
                 },
 
@@ -154,9 +175,17 @@ export function getTypeManifestVisitor(options: TypeManifestOptions) {
                     const childManifest = visit(enumTupleVariantType.tuple, self) as TypeManifest;
                     parentName = originalParentName;
 
+                    const tupleTypes = childManifest.type.replace(/[()]/g, '').split(',').map(s => s.trim());
+                    const fields = tupleTypes.map((type, i) => `final ${type} value${i};`).join('\n');
+                    const constructorArgs = tupleTypes.map((_, i) => `this.value${i}`).join(', ');
+
                     return {
                         ...childManifest,
-                        type: `${name}${childManifest.type},`,
+                        type: `class ${name} extends ${parentName} {
+                            ${fields}
+
+                            ${name}(${constructorArgs});
+                        }`,
                     };
                 },
 
@@ -165,9 +194,7 @@ export function getTypeManifestVisitor(options: TypeManifestOptions) {
                     // Use a default name if no parent name is available
                     const enumName = originalParentName || 'AnonymousEnum';
 
-                    const variants = enumType.variants.map((variant: any) =>
-                        visit(variant, self) as TypeManifest
-                    );
+                    const variants = enumType.variants.map((variant: any) => visit(variant, self) as TypeManifest);
                     const variantNames = variants.map((variant: any) => variant.type).join('\n');
                     const mergedManifest = {
                         imports: new ImportMap().mergeWith(...variants.map((v: any) => v.imports)),
@@ -176,9 +203,8 @@ export function getTypeManifestVisitor(options: TypeManifestOptions) {
 
                     return {
                         ...mergedManifest,
-                        type: `enum ${pascalCase(enumName)} {
-${variantNames}
-}`,
+                        type: `abstract class ${pascalCase(enumName)} {}
+                            ${variantNames}`,
                     };
                 },
 
@@ -219,8 +245,8 @@ ${variantNames}
                         case 'i32':
                             return {
                                 imports: new ImportMap(),
-                                type: 'int',
                                 nestedStructs: [],
+                                type: 'int',
                             };
                         case 'u64':
                         case 'i64':
@@ -228,14 +254,14 @@ ${variantNames}
                         case 'i128':
                             return {
                                 imports: new ImportMap(),
-                                type: 'BigInt',
                                 nestedStructs: [],
+                                type: 'BigInt',
                             };
                         case 'shortU16':
                             return {
                                 imports: new ImportMap(),
-                                type: 'int',
                                 nestedStructs: [],
+                                type: 'int',
                             };
                         default:
                             throw new Error(`Unknown number format: ${numberType.format}`);
@@ -254,8 +280,8 @@ ${variantNames}
                 visitPublicKeyType() {
                     return {
                         imports: new ImportMap().add('package:solana/solana.dart', ['Ed25519HDPublicKey']),
-                        type: 'Ed25519HDPublicKey',
                         nestedStructs: [],
+                        type: 'Ed25519HDPublicKey',
                     };
                 },
 
@@ -275,8 +301,9 @@ ${variantNames}
                 visitStringType() {
                     return {
                         imports: new ImportMap(),
-                        type: 'String',
                         nestedStructs: [],
+                        type: 'String',
+
                     };
                 },
 
@@ -284,7 +311,6 @@ ${variantNames}
                     const originalParentName = parentName;
                     const originalInlineStruct = inlineStruct;
                     const originalNestedStruct = nestedStruct;
-
                     const fieldParentName = originalParentName || 'AnonymousStruct';
 
                     parentName = pascalCase(fieldParentName) + pascalCase(structFieldType.name);
@@ -302,10 +328,10 @@ ${variantNames}
 
                     return {
                         ...fieldManifest,
-                        type: fieldManifest.type,
-                        nestedStructs: fieldManifest.nestedStructs,
+                        field: `${docblock} final ${fieldManifest.type} ${fieldName};`,
                         imports: fieldManifest.imports,
-                        field: `${docblock}  final ${fieldManifest.type} ${fieldName};`,
+                        nestedStructs: fieldManifest.nestedStructs,
+                        type: fieldManifest.type,                    
                     };
                 },
 
@@ -313,7 +339,10 @@ ${variantNames}
                     const originalParentName = parentName;
                     // Use a default name if no parent name is available
                     const structName = originalParentName || 'AnonymousStruct';
-
+                    
+                    // In Dart, every variable must be initialized, either via constructor or with a default value.
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                    const classConstrutor = `  ${pascalCase(structName)}({\n${structType.fields.map((field: any) => `    required this.${snakeCase(field.name)},`).join('\n')}\n  });\n`;
                     const fields = structType.fields.map((field: any) =>
                         visit(field, self) as TypeManifest
                     );
@@ -326,11 +355,14 @@ ${variantNames}
                     if (nestedStruct) {
                         return {
                             ...mergedManifest,
+                            isStruct: true,
                             nestedStructs: [
                                 ...mergedManifest.nestedStructs,
                                 `class ${pascalCase(structName)} {
-${fieldTypes}
-}`,
+                                ${fieldTypes}
+
+                                ${classConstrutor}
+                                }`,
                             ],
                             type: pascalCase(structName),
                         };
@@ -339,15 +371,20 @@ ${fieldTypes}
                     if (inlineStruct) {
                         return {
                             ...mergedManifest, type: `{
-${fieldTypes}
-}` };
+                            ${fieldTypes}
+
+                            ${classConstrutor}
+                            }` 
+                        };
                     }
 
                     return {
                         ...mergedManifest,
                         type: `class ${pascalCase(structName)} {
-${fieldTypes}
-}`,
+                        ${fieldTypes}
+
+                        ${classConstrutor}
+                        }`,
                     };
                 },
 
@@ -368,8 +405,8 @@ ${fieldTypes}
                 visitDateTimeType() {
                     return {
                         imports: new ImportMap(),
-                        type: 'DateTime',
                         nestedStructs: [],
+                        type: 'DateTime',
                     };
                 },
             }),

--- a/packages/renderers-dart/src/utils/linkOverrides.ts
+++ b/packages/renderers-dart/src/utils/linkOverrides.ts
@@ -43,7 +43,7 @@ export function getImportFromFactory(overrides: LinkOverrides): GetImportFromFun
             case 'accountLinkNode':
                 return linkOverrides.accounts[node.name] ?? (fallback ?? 'generated_accounts');
             case 'definedTypeLinkNode':
-                return linkOverrides.definedTypes[node.name] ?? (fallback ?? 'generated_types');
+                return linkOverrides.definedTypes[node.name] ?? (fallback ?? 'types');
             case 'instructionLinkNode':
                 return linkOverrides.instructions[node.name] ?? (fallback ?? 'generated_instructions');
             case 'pdaLinkNode':


### PR DESCRIPTION
# What

### Improved extractFieldsFromTypeManifest to capture baseType, nesting, and optional for fields.
- Handles lists, fixed-length arrays, and optional types accurately.
- Adds detection for struct types to differentiate between primitives and user-defined structs.
- Find the baseType of the element if it is inside a nested structure

### Updated getTypeManifestVisitor to:
- Correctly generate Dart classes for structs, enums, and tuple/struct variants.
- Support optional fields (Type?) and nested structs.
- Map Rust number types to Dart types (int, BigInt) correctly.


### Consistently use `snake_case` for file names and `PascalCase` for class/type names in Dart.

- Ensured the RenderMap visitor passes all required context for accounts, types, instructions, and PDAs.


### Note: In the next PR i will apply typization and fix all eslint errors 

Add appropriate imports for typed arrays, Solana types, and shared utilities.
# Dependent PR
#2 